### PR TITLE
Refactor dump2img.py

### DIFF
--- a/dump2img.py
+++ b/dump2img.py
@@ -1,97 +1,86 @@
-import os
 import argparse
-from PIL import Image
+import os
 import time
-timestr = time.strftime("%Y%m%d - %H%M%S")
 
-#get arguments and set default values
-parser = argparse.ArgumentParser()
-parser.add_argument("-s","--scale", type=int,help="scale factor for image resizing as int, default = 1")
-parser.add_argument("-c0","--color0",nargs=3,type=int,help="substitute color for black in rgb, default = 0 0 0")
-parser.add_argument("-c1","--color1",nargs=3,type=int,help="substitute color for gray in rgb, default = 90 90 90")
-parser.add_argument("-c2","--color2",nargs=3,type=int,help="substitute color for light gray in rgb, default = 180 180 180")
-parser.add_argument("-c3","--color3",nargs=3,type=int,help="substitute color for white in rgb, default = 255 255 255")
-parser.add_argument("-o","--out_filename",help="output filename, default = 'Game Boy Photo'")
-parser.add_argument("-i","--in_filename",help="input filename, default = 'gbDump.out'")
-parser.add_argument("-m","--mute",action = 'store_true', help="mutes the scripts outputs, default = not muted")
-parser.add_argument("-f","--cropframe",action = 'store_true', help="crops the frame, default = not cropped")
-#parser.add_argument("-h","--help",help="show this message")
+from PIL import Image
 
-args = parser.parse_args()
-
-# color values
-colors = [(0,0,0),(90,90,90),(180,180,180),(255,255,255)] #default values
-if args.color0: colors[0]=tuple(args.color0)
-if args.color1: colors[1]=tuple(args.color1)
-if args.color2: colors[2]=tuple(args.color2)
-if args.color3: colors[3]=tuple(args.color3)
-
-# this is your dump file
-in_filename = 'gbDump.out'
-if args.in_filename: in_filename = args.in_filename
-f = open(in_filename)
-
-# set output filename
-out_filename = 'Game Boy Photo'
-if args.out_filename: out_filename = args.out_filename
-
-# set scale multiplyer
-if args.scale:
-	scale = args.scale
-else:
-	scale = 1
-
-# here we remove comments, errors and empty lines from the input
-dump = []
-for line in f:
-	if (line[0] not in  ['!','#','{']) and (len(line)>1):
-		dump.append(line[:-1])
-
-# some outputs
-if not args.mute:
-	for line in dump:
-		print(line)
-
-	print(len(dump))
+BLACK = (0, 0, 0)
+DARK_GREY = (90, 90, 90)
+LIGHT_GREY = (180, 180, 180)
+WHITE = (255, 255, 255)
 
 
+def create_image(data, colors=(BLACK, DARK_GREY, LIGHT_GREY, WHITE), mute=False, scale=1, cropframe=False, file_prefix='Game Boy Photo', output_dir='images'):
+    # here we remove comments, errors and empty lines from the input
+    dump = []
+    for line in data:
+        if (line[0] not in ['!', '#', '{']) and (len(line) > 1):
+            dump.append(line.strip())
+
+    # some outputs
+    if not mute:
+        for line in dump:
+            print(line)
+        print(len(dump))
+
+    # 20 tiles width
+    # 18 tiles hight
+    # gb image format: https://www.huderlem.com/demos/gameboy2bpp.html
+    # conversion happens here
+    for c in range(len(dump) // 360):
+        # we create our canvas here
+        img = Image.new('RGB', (20 * 8, 18 * 8), color='green')
+        pixels = img.load()
+        for h in range(18):
+            for w in range(20):
+                tile = bytes.fromhex(dump[(c * 360) + (h * 20) + w])
+                for i in range(8):
+                    for j in range(8):
+                        col = (255, 0, 0)
+                        hi = (tile[i * 2] >> (7 - j)) & 1
+                        lo = (tile[i * 2 + 1] >> (7 - j)) & 1
+                        if hi == 0 and lo == 0:
+                            col = colors[3]
+                        if hi == 1 and lo == 0:
+                            col = colors[2]
+                        if hi == 0 and lo == 1:
+                            col = colors[1]
+                        if hi == 1 and lo == 1:
+                            col = colors[0]
+                        pixels[(w * 8) + j, (h * 8) + i] = col
+        # cropping
+        if cropframe:
+            img = img.crop((16, 16, (18 * 8), (16 * 8)))
+
+        # resizing
+        img = img.resize((img.width * scale, img.height * scale), resample=Image.NEAREST)
+
+        # saving
+        img.save(os.path.join(output_dir, f'{file_prefix} {time.strftime("%Y%m%d - %H%M%S")} {c:03d}.png'))
 
 
-#20 tiles width
-#18 tiles hight
-# gb image format: https://www.huderlem.com/demos/gameboy2bpp.html
-# conversion happens here
-for c in range(int(len(dump)/360)):
-	# we create our canvas here
-	img = Image.new('RGB', (20*8,18*8), color = 'green')
-	pixels = img.load()
-	for h in range(0,18):
-		for w in range(0,20):
-			tile = bytes.fromhex(dump[(c*360)+(h*20)+w])
-			for i in range(0,8):
-				for j in range(0,8):
-					col = (255,0,0)
-					hi = (tile[i*2] >> (7-j)) &1
-					lo = (tile[i*2+1] >> (7-j)) &1
-					#print(hi,' ',lo)
-					if hi == 0 and lo == 0:
-						col = colors[3]
-					if hi == 1 and lo == 0:
-						col = colors[2]
-					if hi == 0 and lo == 1:
-						col = colors[1]
-					if hi == 1 and lo == 1:
-						col = colors[0]
-					pixels[(w*8)+j,(h*8)+i] = col
+if __name__ == "__main__":
+    # get arguments and set default values
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-s", "--scale", default=1, type=int, help="scale factor for image resizing as int")
+    parser.add_argument("-c0", "--color0", default=BLACK, nargs=3, type=int, help="substitute color for black in rgb")
+    parser.add_argument("-c1", "--color1", default=DARK_GREY, nargs=3, type=int, help="substitute color for gray in rgb")
+    parser.add_argument("-c2", "--color2", default=LIGHT_GREY, nargs=3, type=int, help="substitute color for light gray in rgb")
+    parser.add_argument("-c3", "--color3", default=WHITE, nargs=3, type=int, help="substitute color for white in rgb")
+    parser.add_argument("-o", "--out_filename", default='Game Boy Photo', help="output filename prefix")
+    parser.add_argument("-d", "--output_dir", default='images', help="output directory")
+    parser.add_argument("-i", "--in_filename", default='gbDump.out', help="input filename")
+    parser.add_argument("-m", "--mute", action='store_true', help="mutes the scripts outputs")
+    parser.add_argument("-f", "--cropframe", action='store_true', help="crops the frame")
 
-	#img.show()
+    args = parser.parse_args()
 
-	#cropping
-	if args.cropframe:
-		img = img.crop((16,16,(18*8),(16*8)))
-	
-	# resizing
-	img = img.resize((img.width*scale,img.height*scale),resample=Image.NEAREST)
-
-	#saving
-	img.save('images/{} {} {:03d}.png'.format(out_filename,timestr,c))
+    with open(args.in_filename) as input:
+        create_image(data=input,
+                     colors=[args.color0, args.color1, args.color2, args.color3],
+                     mute=args.mute,
+                     scale=args.scale,
+                     cropframe=args.cropframe,
+                     file_prefix=args.out_filename,
+                     output_dir=args.output_dir
+                     )

--- a/dump2img.py
+++ b/dump2img.py
@@ -9,6 +9,10 @@ DARK_GREY = (90, 90, 90)
 LIGHT_GREY = (180, 180, 180)
 WHITE = (255, 255, 255)
 
+TILE_WIDTH = 20
+TILE_HEIGHT = 18
+TILE_SIZE = TILE_WIDTH * TILE_HEIGHT
+
 
 def create_image(data, colors=(BLACK, DARK_GREY, LIGHT_GREY, WHITE), mute=False, scale=1, cropframe=False, file_prefix='Game Boy Photo', output_dir='images'):
     # here we remove comments, errors and empty lines from the input
@@ -23,17 +27,15 @@ def create_image(data, colors=(BLACK, DARK_GREY, LIGHT_GREY, WHITE), mute=False,
             print(line)
         print(len(dump))
 
-    # 20 tiles width
-    # 18 tiles hight
     # gb image format: https://www.huderlem.com/demos/gameboy2bpp.html
     # conversion happens here
-    for c in range(len(dump) // 360):
+    for c in range(len(dump) // TILE_SIZE):
         # we create our canvas here
-        img = Image.new('RGB', (20 * 8, 18 * 8), color='green')
+        img = Image.new('RGB', (TILE_WIDTH * 8, TILE_HEIGHT * 8), color='green')
         pixels = img.load()
-        for h in range(18):
-            for w in range(20):
-                tile = bytes.fromhex(dump[(c * 360) + (h * 20) + w])
+        for h in range(TILE_HEIGHT):
+            for w in range(TILE_WIDTH):
+                tile = bytes.fromhex(dump[(c * TILE_SIZE) + (h * TILE_WIDTH) + w])
                 for i in range(8):
                     for j in range(8):
                         col = (255, 0, 0)

--- a/dump2img.py
+++ b/dump2img.py
@@ -31,7 +31,7 @@ def create_image(data, colors=(BLACK, DARK_GREY, LIGHT_GREY, WHITE), mute=False,
     # conversion happens here
     for c in range(len(dump) // TILE_SIZE):
         # we create our canvas here
-        img = Image.new('RGB', (TILE_WIDTH * 8, TILE_HEIGHT * 8), color='green')
+        img = Image.new(mode='RGB', size=(TILE_WIDTH * 8, TILE_HEIGHT * 8))
         pixels = img.load()
         for h in range(TILE_HEIGHT):
             for w in range(TILE_WIDTH):


### PR DESCRIPTION
This is a refactor of the the dump2img script.   The CLI usage has not changed but I refactored it to allow for importing into other projects and cleaned up the code a little bit.  

The only functional change is that I added a output_dir flag that defaults to `images` but can now be set to anything.

I really appreciate this project and have enjoyed playing around with it as I just received a Gameboy Camera today and am incorporating it into a project.

I can take a swing at `rgbDump2img.py` as well if that is of any interest.  :) 